### PR TITLE
Initial support for Django 1.10 and Python 3

### DIFF
--- a/djangooidc/urls.py
+++ b/djangooidc/urls.py
@@ -1,12 +1,12 @@
 # coding: utf-8
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from . import views
 
-urlpatterns = patterns('',
-                       url(r'^login$', views.openid, name='openid'),
-                       url(r'^openid/(?P<op_name>.+)$', views.openid, name='openid_with_op_name'),
-                       url(r'^callback/login/?$', views.authz_cb, name='openid_login_cb'),
-                       url(r'^logout$', views.logout, name='logout'),
-                       url(r'^callback/logout/?$', views.logout_cb, name='openid_logout_cb'),
-                       )
+urlpatterns = [
+    url(r'^login$', views.openid, name='openid'),
+    url(r'^openid/(?P<op_name>.+)$', views.openid, name='openid_with_op_name'),
+    url(r'^callback/login/?$', views.authz_cb, name='openid_login_cb'),
+    url(r'^logout$', views.logout, name='logout'),
+    url(r'^callback/logout/?$', views.logout_cb, name='openid_logout_cb'),
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 setuptools>6
-django>=1.8,<1.9
+django>=1.8,<1.11
 oic>=0.9.4,<0.10


### PR DESCRIPTION
This:

* replaces `except Exception, e` with `except Exception as e` for Py3 support
* moves to `django.shortcuts.render` from `render_to_response` for Dj1.10 support
* changes the requirement to include Django 1.9 and Django 1.10
* fixes an import to try the Py3 module path
* stops using `django.conf.urls.patterns`

This should maintain Django 1.8 support (having looked back through the Django docs)