### PR TITLE
Received state not the same as expected 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,11 @@
+Django OIDC Authentication Plugin
+=================================
+
+Note: Currently version numbers are the version numbers tagged in the
+jhuapl-boss/djangooidc repository and don't correspond to the version
+used by `setup.py`.
+
+- v0.9.0 : Merged in PRs and addressed an Issue
+  - Merged in PR #3 and PR #9 (Replacing `render_to_response` with `render`)
+  - Fixed issue #2 with `client.callback()` returning `OIDCError` instead of
+    raising the exception

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Note: Currently version numbers are the version numbers tagged in the
 jhuapl-boss/djangooidc repository and don't correspond to the version
 used by `setup.py`.
 
-- v0.9.0 : Merged in PRs and addressed an Issue
+- v1.1 : Merged in PRs and addressed an Issue
   - Merged in PR #3 and PR #9 (Replacing `render_to_response` with `render`)
   - Fixed issue #2 with `client.callback()` returning `OIDCError` instead of
     raising the exception

--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,9 @@ Quickstart
 
 Install djangooidc::
 
-    # Latest code - unstable!
+    # Latest code
     pip install git+https://github.com/jhuapl-boss/django-oidc.git
-    
+
 
 Then to use it in a Django project, add this to your urls.py::
 

--- a/README.rst
+++ b/README.rst
@@ -5,16 +5,15 @@ This module makes it easy to integrate OpenID Connect as an authentication sourc
 
 Behind the scenes, it uses Roland Hedberg's great pyoidc library.
 
+Modified by JHUAPL BOSS to support Python3
+
 Quickstart
 ----------
 
 Install djangooidc::
 
-    # Latest released package:
-    pip install django-oidc
-    
     # Latest code - unstable!
-    pip install git+https://github.com/marcanpilami/django-oidc.git
+    pip install git+https://github.com/jhuapl-boss/django-oidc.git
     
 
 Then to use it in a Django project, add this to your urls.py::

--- a/djangooidc/oidc.py
+++ b/djangooidc/oidc.py
@@ -2,8 +2,8 @@
 
 from django.conf import settings
 from oic.exception import MissingAttribute
-from oic import oic
-from oic.oauth2 import rndstr, ErrorResponse
+from oic import oic, rndstr
+from oic.oauth2 import ErrorResponse
 from oic.oic import ProviderConfigurationResponse, AuthorizationResponse
 from oic.oic import RegistrationResponse
 from oic.oic import AuthorizationRequest

--- a/djangooidc/oidc.py
+++ b/djangooidc/oidc.py
@@ -81,14 +81,14 @@ class Client(oic.Client):
             if authresp["error"] == "login_required":
                 return self.create_authn_request(session)
             else:
-                return OIDCError("Access denied")
+                raise OIDCError("Access denied")
 
         if session["state"] != authresp["state"]:
-            return OIDCError("Received state not the same as expected.")
+            raise OIDCError("Received state not the same as expected.")
 
         try:
             if authresp["id_token"] != session["nonce"]:
-                return OIDCError("Received nonce not the same as expected.")
+                raise OIDCError("Received nonce not the same as expected.")
             self.id_token[authresp["state"]] = authresp["id_token"]
         except KeyError:
             pass

--- a/djangooidc/oidc.py
+++ b/djangooidc/oidc.py
@@ -24,11 +24,12 @@ class OIDCError(Exception):
 
 
 class Client(oic.Client):
-    def __init__(self, client_id=None, ca_certs=None,
+    def __init__(self, client_id=None, 
                  client_prefs=None, client_authn_method=None, keyjar=None,
                  verify_ssl=True, behaviour=None):
-        oic.Client.__init__(self, client_id, ca_certs, client_prefs,
-                            client_authn_method, keyjar, verify_ssl)
+        oic.Client.__init__(self, client_id=client_id, client_prefs=client_prefs,
+                            client_authn_method=client_authn_method, keyjar=keyjar,
+                            verify_ssl=verify_ssl)
         if behaviour:
             self.behaviour = behaviour
 

--- a/djangooidc/urls.py
+++ b/djangooidc/urls.py
@@ -1,12 +1,12 @@
 # coding: utf-8
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from . import views
 
-urlpatterns = patterns('',
-                       url(r'^login$', views.openid, name='openid'),
-                       url(r'^openid/(?P<op_name>.+)$', views.openid, name='openid_with_op_name'),
-                       url(r'^callback/login/?$', views.authz_cb, name='openid_login_cb'),
-                       url(r'^logout$', views.logout, name='logout'),
-                       url(r'^callback/logout/?$', views.logout_cb, name='openid_logout_cb'),
-                       )
+urlpatterns = [
+    url(r'^login$', views.openid, name='openid'),
+    url(r'^openid/(?P<op_name>.+)$', views.openid, name='openid_with_op_name'),
+    url(r'^callback/login/?$', views.authz_cb, name='openid_login_cb'),
+    url(r'^logout$', views.logout, name='logout'),
+    url(r'^callback/logout/?$', views.logout_cb, name='openid_logout_cb'),
+]

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth import logout as auth_logout, authenticate, login
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.views import login as auth_login_view, logout as auth_logout_view
-from django.shortcuts import redirect, render_to_response, resolve_url
+from django.shortcuts import redirect, render, resolve_url
 from django.http import HttpResponse, HttpResponseRedirect
 from django import forms
 from django.template import RequestContext
@@ -59,7 +59,7 @@ def openid(request, op_name=None):
                 request.session["op"] = client.provider_info["issuer"]
             except Exception as e:
                 logger.exception("could not create OOID client")
-                return render_to_response("djangooidc/error.html", {"error": e})
+                return render(request, "djangooidc/error.html", {"error": e})
     else:
         form = DynamicProvider()
 
@@ -68,13 +68,12 @@ def openid(request, op_name=None):
         try:
             return client.create_authn_request(request.session)
         except Exception as e:
-            return render_to_response("djangooidc/error.html", {"error": e})
+            return render(request, "djangooidc/error.html", {"error": e})
 
     # Otherwise just render the list+form.
-    return render_to_response(template_name,
+    return render(request, template_name,
                               {"op_list": [i for i in settings.OIDC_PROVIDERS.keys() if i], 'dynamic': dyn,
-                               'form': form, 'ilform': ilform, "next": request.session["next"]},
-                              context_instance=RequestContext(request))
+                               'form': form, 'ilform': ilform, "next": request.session["next"]})
 
 
 # Step 4: analyze the token returned by the OP
@@ -94,7 +93,7 @@ def authz_cb(request):
             raise Exception('this login is not valid in this application')
     except OIDCError as e:
         logging.getLogger('djangooidc.views.authz_cb').exception('Problem logging user in')
-        return render_to_response("djangooidc/error.html", {"error": e, "callback": query})
+        return render(request, "djangooidc/error.html", {"error": e, "callback": query})
 
 
 def logout(request, next_page=None):

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -93,6 +93,7 @@ def authz_cb(request):
         else:
             raise Exception('this login is not valid in this application')
     except OIDCError as e:
+        logging.getLogger('djangooidc.views.authz_cb').exception('Problem logging user in')
         return render_to_response("djangooidc/error.html", {"error": e, "callback": query})
 
 

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -86,7 +86,7 @@ def authz_cb(request):
         query = parse_qs(request.META['QUERY_STRING'])
         userinfo = client.callback(query, request.session)
         request.session["userinfo"] = userinfo
-        user = authenticate(**userinfo)
+        user = authenticate(request=request, **userinfo)
         if user:
             login(request, user)
             return redirect(request.session["next"])

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -139,7 +139,8 @@ def logout(request, next_page=None):
             request_args = {'id_token': IdToken(**request.session['id_token'])}
         res = client.do_end_session_request(state=request.session["state"],
                                             extra_args=extra_args, request_args=request_args)
-        resp = HttpResponse(content_type=res.headers["content-type"], status=res.status_code, content=res._content)
+        content_type = res.headers.get("content-type", "text/html") # In case the logout response doesn't set content-type (Seen with Keycloak)
+        resp = HttpResponse(content_type=content_type, status=res.status_code, content=res._content)
         for key, val in res.headers.items():
             resp[key] = val
         return resp

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import logging
-from urlparse import parse_qs
+from urllib.parse import parse_qs
 
 from django.conf import settings
 from django.contrib.auth import logout as auth_logout, authenticate, login
@@ -56,7 +56,7 @@ def openid(request, op_name=None):
             try:
                 client = CLIENTS.dynamic_client(form.cleaned_data["hint"])
                 request.session["op"] = client.provider_info["issuer"]
-            except Exception, e:
+            except Exception as e:
                 logger.exception("could not create OOID client")
                 return render_to_response("djangooidc/error.html", {"error": e})
     else:
@@ -66,7 +66,7 @@ def openid(request, op_name=None):
     if client:
         try:
             return client.create_authn_request(request.session)
-        except Exception, e:
+        except Exception as e:
             return render_to_response("djangooidc/error.html", {"error": e})
 
     # Otherwise just render the list+form.

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -138,9 +138,7 @@ def logout(request, next_page=None):
         # DP HACK: Needed to get logout to actually logout from the OIDC Provider
         # According to ODIC session spec (http://openid.net/specs/openid-connect-session-1_0.html#RPLogout)
         # the user should be directed to the OIDC provider to logout after being
-        # logged out here. The commented code makes a logout call to the OIDC Provider
-        # on behalf of the user. The request it makes doesn't conform to the spec above
-        # and fails to actually log the user out of the provider.
+        # logged out here.
 
         request_args = {
             'id_token_hint': request.session['access_token'],
@@ -154,6 +152,9 @@ def logout(request, next_page=None):
         url += "?" + urlencode(request_args)
         return HttpResponseRedirect(url)
 
+        # Looks like they are implementing back channel logout, without checking for
+        # support?
+        # http://openid.net/specs/openid-connect-backchannel-1_0.html#Backchannel
         """
         request_args = None
         if 'id_token' in request.session.keys():

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -1,24 +1,22 @@
 # coding: utf-8
 
 import logging
-from urllib.parse import parse_qs
-from urllib.parse import urlencode
-
+from django import forms
 from django.conf import settings
-from django.contrib.auth import logout as auth_logout, authenticate, login
+from django.contrib.auth import authenticate, login, logout as auth_logout
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.views import login as auth_login_view, logout as auth_logout_view
-from django.shortcuts import redirect, render_to_response, resolve_url
-from django.http import HttpResponse, HttpResponseRedirect
-from django import forms
-from django.template import RequestContext
-from oic.oic.message import IdToken
+from django.http import HttpResponseRedirect
+from django.shortcuts import redirect, render, resolve_url
+from urllib.parse import parse_qs, urlencode
 
 from djangooidc.oidc import OIDCClients, OIDCError
 
 logger = logging.getLogger(__name__)
 
 CLIENTS = OIDCClients(settings)
+
+ERROR_TEMPLATE = "djangooidc/error.html"
 
 
 # Step 1: provider choice (form). Also - Step 2: redirect to OP. (Step 3 is OP business.)
@@ -59,7 +57,7 @@ def openid(request, op_name=None):
                 request.session["op"] = client.provider_info["issuer"]
             except Exception as e:
                 logger.exception("could not create OOID client")
-                return render_to_response("djangooidc/error.html", {"error": e})
+                return render(request, ERROR_TEMPLATE, context={"error": e})
     else:
         form = DynamicProvider()
 
@@ -68,13 +66,12 @@ def openid(request, op_name=None):
         try:
             return client.create_authn_request(request.session)
         except Exception as e:
-            return render_to_response("djangooidc/error.html", {"error": e})
+            return render(request, ERROR_TEMPLATE, context={"error": e})
 
     # Otherwise just render the list+form.
-    return render_to_response(template_name,
-                              {"op_list": [i for i in settings.OIDC_PROVIDERS.keys() if i], 'dynamic': dyn,
-                               'form': form, 'ilform': ilform, "next": request.session["next"]},
-                              context_instance=RequestContext(request))
+    return render(request, template_name,
+                  context={"op_list": [i for i in settings.OIDC_PROVIDERS.keys() if i], 'dynamic': dyn,
+                           'form': form, 'ilform': ilform, "next": request.session["next"]}, )
 
 
 # Step 4: analyze the token returned by the OP
@@ -94,7 +91,7 @@ def authz_cb(request):
             raise Exception('this login is not valid in this application')
     except OIDCError as e:
         logging.getLogger('djangooidc.views.authz_cb').exception('Problem logging user in')
-        return render_to_response("djangooidc/error.html", {"error": e, "callback": query})
+        return render(request, ERROR_TEMPLATE, context={"error": e, "callback": query})
 
 
 def logout(request, next_page=None):
@@ -145,7 +142,7 @@ def logout(request, next_page=None):
             'id_token_hint': request.session['access_token'],
             'state': request.session['state'],
         }
-        request_args.update(extra_args) # should include the post_logout_redirect_uri
+        request_args.update(extra_args)  # should include the post_logout_redirect_uri
 
         # id_token iss is the token issuer, the url of the issuing server
         # the full url works for the BOSS OIDC Provider, not tested on any other provider
@@ -159,7 +156,7 @@ def logout(request, next_page=None):
         """
         request_args = None
         if 'id_token' in request.session.keys():
-            request_args = {'id_token': IdToken(**request.session['id_token'])}
+            request_args = {'id_token': oic.oic.message.IdToken(**request.session['id_token'])}
         res = client.do_end_session_request(state=request.session["state"],
                                             extra_args=extra_args, request_args=request_args)
         content_type = res.headers.get("content-type", "text/html") # In case the logout response doesn't set content-type (Seen with Keycloak)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-oic==0.13.0
 setuptools>6
 django>=1.8,<1.9
+-e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-setuptools>6
-django>=1.8,<1.9
--e .
+.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+oic==0.13.0
 setuptools>6
 django>=1.8,<1.9
-oic==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 setuptools>6
 django>=1.8,<1.9
-oic>=0.7.6
+oic==0.13.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'django>=1.8',
-        'oic>=0.7.6',
+        'oic==0.13.0',
     ],
     license="Apache Software License",
     zip_safe=False,


### PR DESCRIPTION
Hi @derek-pryor ,

I got this error:
**Received state not the same as expected**

```
Request Method: | GET
-- | --
http://192.168.1.50:8080/openid/callback/login/?state=Kx4kDQeKx9eIf2yi&code=nJkevjwcvG6TtuXKkH01VttXeduv2CKiO9FcYMFy3w4.041cb6c1-82a6-47cd-b09c-08fcc7a61dbe
1.11.5
TypeError
authenticate() argument after ** must be a mapping, not OIDCError
/usr/local/lib/python3.5/dist-packages/djangooidc/views.py in authz_cb, line 89
/usr/bin/python3

Request Method: | GET
-- | --
http://192.168.1.50:8080/openid/callback/login/?state=Kx4kDQeKx9eIf2yi&code=nJkevjwcvG6TtuXKkH01VttXeduv2CKiO9FcYMFy3w4.041cb6c1-82a6-47cd-b09c-08fcc7a61dbe
1.11.5
TypeError
authenticate() argument after ** must be a mapping, not OIDCError
/usr/local/lib/python3.5/dist-packages/djangooidc/views.py in authz_cb, line 89
/usr/bin/python3

```


How can I fix this error?
